### PR TITLE
change 'open' to 'xdg-open'

### DIFF
--- a/autoload/vim_seq_diag.vim
+++ b/autoload/vim_seq_diag.vim
@@ -34,7 +34,7 @@ function! vim_seq_diag#Generate_diagram(pluginPath)
   if has('mac')
     call system("osascript " . a:pluginPath . '/applescript/active.scpt')
   else
-    call system("open " . out)
+    call system("xdg-open " . out)
   endif
 endfunction
 


### PR DESCRIPTION
On many Linux system, the 'open' is the old name of 'openvt' which has nothing to do with open a file.
The 'xdg-open' is a freedesktop.org specified way of open file in the default program.